### PR TITLE
Package for apt/homebrew

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,33 +6,29 @@ linux:
     script:
         - apt-get update
         - apt-get install --no-install-recommends xz-utils curl git ca-certificates -y
+        - curl -s https://packagecloud.io/install/repositories/anarchytools/AT/script.deb.sh | bash
+        - apt-get install atbuild --install-suggests
         - git submodule update --recursive --init
-        - curl -L https://github.com/AnarchyTools/atbuild/releases/download/0.10.0/atbuild-0.10.0-linux.tar.xz | tar xJ
-        - cp atbuild-*/atbuild /usr/local/bin/
         - atbuild check
-        - atbuild atpm --use-overlay static
-        - mkdir atpm-${CI_BUILD_REF}
-        - cp bin/atpm atpm-${CI_BUILD_REF}
-        - tar cJf atpm-${CI_BUILD_REF}-linux.tar.xz atpm-${CI_BUILD_REF}
+        - atbuild package --use-overlay static
     tags:
         - autoscale-linux
     image: drewcrawford/swift:latest
     artifacts:
         paths:
-            - atpm-${CI_BUILD_REF}-linux.tar.xz
+            - bin/atpm-*.tar.xz
+            - bin/*.deb
 
 osx:
     stage: build
     script:
         - git submodule update --recursive --init
         - atbuild check
-        - atbuild atpm --use-overlay static
-        - mkdir atpm-${CI_BUILD_REF}
-        - cp bin/atpm atpm-${CI_BUILD_REF}
-        - tar cJf atpm-${CI_BUILD_REF}-osx.tar.xz atpm-${CI_BUILD_REF}
+        - atbuild package --use-overlay static
     tags:
         - openswift
         - atbuild
     artifacts:
         paths:
-            - atpm-${CI_BUILD_REF}-osx.tar.xz
+            - bin/atpm-*.tar.xz
+            - bin/atpm.rb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ linux:
         - apt-get update
         - apt-get install --no-install-recommends xz-utils curl git ca-certificates -y
         - curl -s https://packagecloud.io/install/repositories/anarchytools/AT/script.deb.sh | bash
-        - apt-get install atbuild --install-suggests
+        - apt-get install atbuild package-deb -y
         - git submodule update --recursive --init
         - atbuild check
         - atbuild package --use-overlay static

--- a/build.atpkg
+++ b/build.atpkg
@@ -80,6 +80,7 @@
       :atllbuild-task "atpm"
       :platforms ["all"]
       :name "atpm"
+      :compress true
     }
 
     :package-linux {

--- a/build.atpkg
+++ b/build.atpkg
@@ -17,6 +17,7 @@
 (package
   :name "atpm"
   :import-packages ["atpkg/build.atpkg"]
+  :version "1.0.1"
 
   :tasks {
     :default {
@@ -72,6 +73,35 @@
           :link-options ["-static-stdlib"]
         }
       }
+    }
+
+    :atbin {
+      :tool "packageatbin"
+      :atllbuild-task "atpm"
+      :platforms ["all"]
+      :name "atpm"
+    }
+
+    :package-linux {
+      :only-platforms ["linux"]
+      :tool "package-deb.attool"
+      :name "atpm"
+      :dependencies ["atbin"]
+      :depends "git"
+    }
+
+
+    :package-osx {
+      :only-platforms ["osx"]
+      :tool "package-homebrew.attool"
+      :dependencies ["atbin"]
+      :name "atpm"
+      :github-project "AnarchyTools/atpm"
+    }
+
+    :package {
+      :tool "nop"
+      :dependencies ["package-linux" "package-osx"]
     }
 
     :check {


### PR DESCRIPTION
This implements homebrew and apt packaging for atpm.

Note that I've already packaged 1.0.1 for apt/homebrew (you can install now!).  No atpm changes are required, it's just a matter of building via atbuild 1.2 and updating the CI definitions a bit.  I'm PRing those definitions so you can merge at your convenience.

I documented the whole release process here:
- [package-homebrew](https://github.com/AnarchyTools/package-homebrew)
- [package-deb](https://github.com/AnarchyTools/package-deb)

But it mostly consists of grabbing packages out of CI and then uploading them to the right places for the platform package manager to find.  In homebrew's case we can host them, in Debian's case we use packagecloud.io.

If you register for a packagecloud.io account I will add you as a collaborator on the apt repo and you can upload future debs yourself.

Our deb packages are probably okay for Ubuntu too, but I haven't actually tried it (don't normally use Ubuntu) so I don't know.
