### PR TITLE
Binary releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ linux:
     stage: build
     script:
         - apt-get update
-        - apt-get install --no-install-recommends xz-utils curl git ca-certificates -y
+        - apt-get install --no-install-recommends xz-utils curl git ca-certificates curl -y
         - curl -s https://packagecloud.io/install/repositories/anarchytools/AT/script.deb.sh | bash
         - apt-get install atbuild package-deb -y
         - git submodule update --recursive --init

--- a/atpm/src/dependency.swift
+++ b/atpm/src/dependency.swift
@@ -1,0 +1,74 @@
+// Copyrhs (c) 2016 Anarchy Tools Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import atpkg
+import atfoundation
+import atpm_tools
+
+func chooseVersion(versions: [Version], versionRange: VersionRange) throws -> Version? {
+    var versions = versions
+    versions = try versions.filter { version throws -> Bool in
+        return versionRange.versionInRange(version)
+    }
+
+    versions.sort(isOrderedBefore: { (v1, v2) -> Bool in
+        return v1 < v2
+    })
+
+    if versions.count > 0 {
+        print("Valid versions: \(versions), using \(versions.last!)")
+        return versions.last!
+    } else {
+        print("No valid versions!")
+        return nil
+    }
+}
+
+func updateDependency(_ pkg: ExternalDependency, lock: LockedPackage?, firstTime: Bool = false) throws {
+    switch(pkg.dependencyType) {
+        case .Git:
+        try updateGitDependency(pkg, lock: lock, firstTime: firstTime)
+        case .Manifest:
+        print("todo")
+        break
+    }
+}
+
+//- returns: The name of the depency we downloaded
+func fetchDependency(_ pkg: ExternalDependency, lock: LockedPackage?) throws {
+
+    //note that this check only works for git dependencies – 
+    //binary dependencies names are defined in the manifest
+    if let name = pkg.name {
+        if FS.fileExists(path: Path("external/\(name)")) {
+            print("Already downloaded")
+            return
+        }
+    }
+    
+    let ext = Path("external")
+    if !FS.fileExists(path: ext) {
+        try FS.createDirectory(path: ext)
+    }
+
+    switch(pkg.dependencyType) {
+        case .Git:
+        try fetchGitDependency(pkg, lock: lock)
+
+        case .Manifest:
+        try fetchHTTPDependency(pkg, lock: lock)
+    }
+
+
+}
+

--- a/atpm/src/dependency.swift
+++ b/atpm/src/dependency.swift
@@ -15,7 +15,19 @@ import atpkg
 import atfoundation
 import atpm_tools
 
-func chooseVersion(versions: [Version], versionRange: VersionRange) throws -> Version? {
+///Choose a version
+///- parameter versions: The set of legal versions we could choose
+///- parameter versionRange: Version specifiers such as are provided in a build.atpkg
+///- parameter lockedPayload: Use this payload to choose a version if possible
+func chooseVersion(versions: [Version], versionRange: VersionRange, lockedPayload: LockedPayload?) throws -> Version? {
+    if let v = lockedPayload?.usedVersion {
+        guard let lockedVersion = try versions.filter({ version throws -> Bool in
+            return version.description == v
+        }).first else {
+            fatalError("Can't find version \(v) to fetch.  Use update to resolve.")
+        }
+        return lockedVersion
+    }
     var versions = versions
     versions = try versions.filter { version throws -> Bool in
         return versionRange.versionInRange(version)

--- a/atpm/src/error.swift
+++ b/atpm/src/error.swift
@@ -2,6 +2,9 @@ public enum PMError: ErrorProtocol, CustomStringConvertible {
 	case GitError(exitCode: Int32)
 	case MissingPackageCheckout
 	case InvalidVersion
+	case InsecurePackage
+	case HTTPSTransportError(exitCode: Int32)
+	case TarError(exitCode: Int32)
 
 	public var description: String {
 		switch self {
@@ -11,6 +14,12 @@ public enum PMError: ErrorProtocol, CustomStringConvertible {
 			return "Missing checkout, run 'atpm fetch'"
 		case .InvalidVersion:
 			return "Version invalid"
+		case .InsecurePackage:
+			return "Package must be loaded over HTTPS or other secure method"
+		case .HTTPSTransportError (let exitCode):
+			return "An error occurred while loading an HTTPS resource \(exitCode)"
+		case .TarError (let exitCode):
+			return "An error occurred while untarring a binary package \(exitCode)"
 		}
 	}
 }

--- a/atpm/src/git.swift
+++ b/atpm/src/git.swift
@@ -22,7 +22,7 @@ func fetchVersions(_ pkg: ExternalDependency) -> [Version] {
         return []
     }
     defer {
-        fclose(fp)
+        pclose(fp)
     }
 
     var versions = [Version]()

--- a/atpm/src/git.swift
+++ b/atpm/src/git.swift
@@ -95,7 +95,7 @@ func updateGitDependency(_ pkg: ExternalDependency, lock: LockedPackage?, firstT
         }
         let versions = fetchVersions(pkg)
 
-        guard let version = try chooseVersion(versions: versions, versionRange: versionRange) else {
+        guard let version = try chooseVersion(versions: versions, versionRange: versionRange, lockedPayload:lock?.payloadMatching(key: "git")) else {
             throw PMError.InvalidVersion
         }
         let pullResult = logAndExecute(command: "cd 'external/\(pkg.name!)' && git checkout '\(version)'")

--- a/atpm/src/git.swift
+++ b/atpm/src/git.swift
@@ -52,9 +52,9 @@ func updateGitDependency(_ pkg: ExternalDependency, lock: LockedPackage?, firstT
     }
 
     // If we are pinned only checkout that commit
-    if let lock = lock where lock.gitPayload.pinnedCommitID != nil {
-        print("Package \(pkg.name!) is pinned to \(lock.gitPayload.pinnedCommitID!)")
-        let pullResult = logAndExecute(command: "cd 'external/\(pkg.name!)' && git checkout '\(lock.gitPayload.pinnedCommitID!)'")
+    if let lock = lock where lock.gitPayload.pinned != nil {
+        print("Package \(pkg.name!) is pinned to \(lock.gitPayload.usedCommitID!)")
+        let pullResult = logAndExecute(command: "cd 'external/\(pkg.name!)' && git checkout '\(lock.gitPayload.usedCommitID!)'")
         if pullResult != 0 {
             throw PMError.GitError(exitCode: pullResult)
         }
@@ -95,7 +95,7 @@ func updateGitDependency(_ pkg: ExternalDependency, lock: LockedPackage?, firstT
         }
         let versions = fetchVersions(pkg)
 
-        guard let version = try chooseVersion(versions: versions, versionRange: versionRange, lockedPayload:lock?.payloadMatching(key: "git")) else {
+        guard let version = try chooseVersion(versions: versions, versionRange: versionRange, lockedPayload:lock?.payloadMatching(key: "git"), update: false) else {
             throw PMError.InvalidVersion
         }
         let pullResult = logAndExecute(command: "cd 'external/\(pkg.name!)' && git checkout '\(version)'")

--- a/atpm/src/git.swift
+++ b/atpm/src/git.swift
@@ -138,7 +138,6 @@ func updateGitLockPackage(pkg: ExternalDependency, lockedPackage: inout LockedPa
 }
 func getCurrentCommitID(_ pkg: ExternalDependency) -> String? {
     if !FS.fileExists(path: Path("external/\(pkg.name!)")) {
-        print("here")
         return nil
     }
     let fp = popen("cd 'external/\(pkg.name!)' && git rev-parse HEAD", "r")
@@ -154,7 +153,6 @@ func getCurrentCommitID(_ pkg: ExternalDependency) -> String? {
             break
         }
         if let commitID = String(validatingUTF8: buffer) {
-            print("returning \(commitID)")
             return commitID.subString(toIndex: commitID.index(commitID.startIndex, offsetBy: commitID.characters.count - 1))
         }
     }

--- a/atpm/src/http.swift
+++ b/atpm/src/http.swift
@@ -85,9 +85,14 @@ func fetchHTTPDependency(_ pkg:ExternalDependency,lock: LockedPackage?, forceUpd
             let atpmVersion = Version(string: manifestVersion.version)
             versions.append(atpmVersion)
         }
+
+        //load the payload out of the lock file if it already exists
+        var lockedPayload: LockedPayload
+        if let lp = lock?.payloadMatching(key: channel) { lockedPayload = lp}
+        else {lockedPayload = LockedPayload(key: channel)}
         
         //figure out which version we need to load
-        guard let versionToLoad = try chooseVersion(versions: versions, versionRange: versionRange) else {
+        guard let versionToLoad = try chooseVersion(versions: versions, versionRange: versionRange, lockedPayload: lockedPayload) else {
             fatalError("Can't find a version matching \(versionRange) in \(versions)")
         }
         
@@ -108,10 +113,7 @@ func fetchHTTPDependency(_ pkg:ExternalDependency,lock: LockedPackage?, forceUpd
             }
         }
 
-        //load the payload out of the lock file if it already exists
-        var lockedPayload: LockedPayload
-        if let lp = lock?.payloadMatching(key: channel) { lockedPayload = lp}
-        else {lockedPayload = LockedPayload(key: channel)}
+
 
         lockedPayload.usedVersion = versionToLoad.description
         lockedPayload.usedURL = binaryVersion.url.description

--- a/atpm/src/http.swift
+++ b/atpm/src/http.swift
@@ -139,7 +139,12 @@ func fetchHTTPDependency(_ pkg:ExternalDependency,lock: LockedPackage?, update: 
 }
 
 private func getSHASum(path: Path) -> String {
-    let fp = popen("shasum -a 256 -b \(path) | cut -d ' ' -f 1 ", "r")
+    #if os(OSX)
+    let cmd = "shasum -a 256 -b \(path) | cut -d ' ' -f 1 "
+    #elseif os(Linux)
+    let cmd = "sha256sum -b \(path) | cut -d ' ' -f 1 "
+    #endif
+    let fp = popen(cmd, "r")
     guard fp != nil else {
         fatalError("fp is nil")
     }

--- a/atpm/src/http.swift
+++ b/atpm/src/http.swift
@@ -39,11 +39,11 @@ private func fetch(url: URL, to file: Path) throws {
 
 func fetchHTTPDependency(_ pkg:ExternalDependency,lock: LockedPackage?, forceUpdate: Bool = false) throws {
     print("Processing HTTP dependency...")
-    let packagePath = Path("external/manifest.atpkg")
-    if !FS.fileExists(path: packagePath) { try FS.createDirectory(path: packagePath) }
 
-
-    let manifestPath = packagePath.appending("manifest.atpkg")
+    //calculate a safe path to store the manifest
+    let manifestName = pkg.url.description.replacing(searchTerm: "/", replacement: "-").replacing(searchTerm: ":", replacement: "-")
+    let manifestPath = Path("external/\(manifestName)")
+    print("saving to \(manifestPath)")
 
     if FS.fileExists(path: manifestPath) && !forceUpdate {
         print("Manifest already exists; won't update")
@@ -54,6 +54,9 @@ func fetchHTTPDependency(_ pkg:ExternalDependency,lock: LockedPackage?, forceUpd
 
     let parsedManifest = try Package(filepath: manifestPath, overlay: [], focusOnTask: nil)
     pkg._parsedNameFromManifest = parsedManifest.name
+    let packagePath = Path("external/\(parsedManifest.name)")
+    if !FS.fileExists(path: packagePath) { try FS.createDirectory(path: packagePath) }
+
     guard let channels = parsedManifest.binaryChannels else { fatalError("No binary channels in manifest ")}
     //what channels should we load?
     let channelsToLoad: [String]

--- a/atpm/src/http.swift
+++ b/atpm/src/http.swift
@@ -1,0 +1,113 @@
+// Copyrhs (c) 2016 Anarchy Tools Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import atfoundation
+import atpkg
+import atpm_tools
+
+///We populate the _applicationInfo with this value
+struct HTTPDependencyInfo {
+    let lockedPayload: LockedPayload
+    let channel: String
+}
+
+///The world's most terrible HTTP implementation
+private func fetch(url: URL, to file: Path) throws {
+    if url.schema != "https" { throw PMError.InsecurePackage }
+    let curlResult = system("curl -sL -o '\(file)' '\(url)'")
+    if curlResult != 0 {
+        throw PMError.HTTPSTransportError(exitCode: curlResult)
+    }
+}
+
+func fetchHTTPDependency(_ pkg:ExternalDependency,lock: LockedPackage?) throws {
+    print("Fetching HTTP dependency...")
+    let manifestPath = try FS.temporaryDirectory().appending("manifest.atpkg")
+
+    try fetch(url: pkg.url, to: manifestPath)
+    let parsedManifest = try Package(filepath: manifestPath, overlay: [], focusOnTask: nil)
+    pkg._parsedNameFromManifest = parsedManifest.name
+    guard let channels = parsedManifest.binaryChannels else { fatalError("No binary channels in manifest ")}
+    //what channels should we load?
+    let channelsToLoad: [String]
+    if let c = pkg.channels {
+        //load specified channels
+        channelsToLoad = c
+    }
+    else  { 
+        //load all available channel
+        channelsToLoad = channels.map({$0.name}) 
+    }
+    for channel in channelsToLoad {
+        //load channel
+        guard let parsedChannel = channels.filter({$0.name == channel}).first else {
+            fatalError("Can't find channel named \(channel) in channels")
+        }
+        //parse version range from build.atpkg
+        guard case .Version(let versionSpecifications) = pkg.version else {
+            fatalError("Only `version` supported in binary specification.  Actual: \(pkg.version)")
+        }
+        let versionRange = VersionRange()
+        for ver in versionSpecifications {
+            try versionRange.combine(ver)
+        }
+        //parse versions from manifest
+        var versions: [Version] = []
+        for manifestVersion in parsedChannel.versions {
+            let atpmVersion = Version(string: manifestVersion.version)
+            versions.append(atpmVersion)
+        }
+        
+        //figure out which version we need to load
+        guard let versionToLoad = try chooseVersion(versions: versions, versionRange: versionRange) else {
+            fatalError("Can't find a version matching \(versionRange) in \(versions)")
+        }
+        
+        let binaryVersion = parsedChannel.versions.filter({$0.version == versionToLoad.description}).first!
+        print("Fetching \(binaryVersion.url)")
+        let packagePath = Path("external/\(parsedManifest.name)")
+        let tarballPath = packagePath.appending("\(binaryVersion.url.path.basename())")
+        if FS.fileExists(path: tarballPath) { try FS.removeItem(path: tarballPath)}
+        if !FS.fileExists(path: packagePath) { try FS.createDirectory(path: packagePath) }
+        try fetch(url: binaryVersion.url, to: tarballPath)
+        print(tarballPath.description)
+        if tarballPath.description.hasSuffix("tar.xz") {
+            print("Expanding tarball...")
+            let result = system("tar xf \(tarballPath) -C \(packagePath)")
+            if result != 0 {
+                throw PMError.TarError(exitCode: result)
+            }
+        }
+    }
+}
+
+private func getSHASum(path: Path) -> String {
+    let fp = popen("shasum -a 256 -b \(path) | cut -d ' ' -f 1 ", "r")
+    guard fp != nil else {
+        fatalError("fp is nil")
+    }
+    defer {
+        pclose(fp)
+    }
+    var buffer = [CChar](repeating: 0, count: 255)
+    while feof(fp) == 0 {
+        if fgets(&buffer, 255, fp) == nil {
+            break
+        }
+        if let shasum = String(validatingUTF8: buffer) {
+            return shasum
+        }
+    }
+    fatalError("Could not calculate shasum for \(path)")
+}
+

--- a/atpm/src/lockfile.swift
+++ b/atpm/src/lockfile.swift
@@ -25,6 +25,24 @@ public struct LockedPackage {
     public let url: URL
     var payloads: [LockedPayload]
 
+    ///Gets a payload matching the key
+    public func payloadMatching(key: String) -> LockedPayload? {
+        if let payload = self.payloads.filter({$0.key == key}).first {
+            return payload
+        }    
+        return nil
+    }
+
+    ///Gets or creates a payload matching the key
+    public mutating func createPayloadMatching(key: String) -> LockedPayload {
+        if let payload = self.payloadMatching(key: key) {
+            return payload
+        }
+        let newPayload = LockedPayload(key: key)
+        self.payloads.append(newPayload)
+        return newPayload
+    }
+
     public var gitPayload : LockedPayload {
         get {
             precondition(payloads.count == 1)

--- a/atpm/src/lockfile.swift
+++ b/atpm/src/lockfile.swift
@@ -93,11 +93,11 @@ public struct LockedPackage {
         var result = [String]()
         result.append("{")
         result.append("  :\(Option.URL.rawValue) \"\(self.url)\"")
-        result.append("  :\(Option.Payloads.rawValue) {")
+        result.append("  :\(Option.Payloads.rawValue) [")
         for payload in payloads {
             result.append(contentsOf: payload.serialize())
         }
-        result.append("  }")
+        result.append("  ]")
         result.append("}")
         return result
     }
@@ -169,11 +169,10 @@ public struct LockedPayload {
         self.key = key
 
 
-        guard let usedCommitID = kvp[Option.UsedCommit.rawValue]?.string else {
-            fatalError("No commit ID for locked package; did you forget to specify it?")
+        if let usedCommitID = kvp[Option.UsedCommit.rawValue]?.string {
+            self.usedCommitID = usedCommitID
         }
 
-        self.usedCommitID = usedCommitID
 
         if let pinnedCommitID = kvp[Option.PinCommit.rawValue]?.string {
             self.usedCommitID = pinnedCommitID

--- a/atpm/src/main.swift
+++ b/atpm/src/main.swift
@@ -73,14 +73,14 @@ func fetch(_ package: Package, lock: LockFile?) -> [ExternalDependency] {
         print("Fetching external dependency \(pkg.name ?? "\(pkg.url)")...")
         do {
             try fetchDependency(pkg, lock: lock?[pkg.url])
-
-            do {
-                try FS.symlinkItem(from: Path(".."), to: Path("external/\(pkg.name!)/external"))
-            }
-        catch SysError.FileExists { /* */ }
-            let subPackagePath = Path("external/\(pkg.name!)/build.atpkg")
             switch(pkg.dependencyType) {
                 case .Git:
+                do {
+                    try FS.symlinkItem(from: Path(".."), to: Path("external/\(pkg.name!)/external"))
+                }
+                catch SysError.FileExists { /* */ }
+                let subPackagePath = Path("external/\(pkg.name!)/build.atpkg")
+
                 do {
                     let p = try Package(filepath: subPackagePath, overlay: [], focusOnTask: nil)
                     packages.append(pkg)

--- a/atpm/src/main.swift
+++ b/atpm/src/main.swift
@@ -227,6 +227,15 @@ func writeLockFile(_ packages: [ExternalDependency], lock: LockFile?) {
             updateGitLockPackage(pkg: pkg, lockedPackage: &lockedPackage)
 
             case .Manifest:
+            //Pull the payloads out of the pkg._applicationInfo
+            //This is set when the dependency was fetched
+            guard let info = pkg._applicationInfo as? HTTPDependencyInfo else {
+                fatalError("No _applicationInfo for manifest")
+            }
+            for payload in info.channels {
+                lockedPackage.payloads.append(payload.lockedPayload)
+            }
+
             break
         }
 

--- a/atpm/src/main.swift
+++ b/atpm/src/main.swift
@@ -232,6 +232,8 @@ func writeLockFile(_ packages: [ExternalDependency], lock: LockFile?) {
             guard let info = pkg._applicationInfo as? HTTPDependencyInfo else {
                 fatalError("No _applicationInfo for manifest")
             }
+            //Overwrite all existing payloads
+            lockedPackage.payloads = []
             for payload in info.channels {
                 lockedPackage.payloads.append(payload.lockedPayload)
             }

--- a/atpm/src/main.swift
+++ b/atpm/src/main.swift
@@ -51,18 +51,24 @@ func info(_ package: Package, indent: Int = 4) -> Bool {
         out += "- \(dep.url)"
         print(out)
 
-        let subPackagePath = Path("external/\(dep.name)/build.atpkg")
-        do {
-            let subPackage = try Package(filepath: subPackagePath, overlay: [], focusOnTask: nil)
-            info(subPackage, indent: indent + 4)
-        } catch {
-            out = ""
-            for _ in 0..<indent {
-                out += " "
+        switch(dep.dependencyType) {
+            case .Git:
+            let subPackagePath = Path("external/\(dep.name)/build.atpkg")
+            do {
+                let subPackage = try Package(filepath: subPackagePath, overlay: [], focusOnTask: nil)
+                info(subPackage, indent: indent + 4)
+            } catch {
+                out = ""
+                for _ in 0..<indent {
+                    out += " "
+                }
+                out += "-> Could not load Package file: \(error)"
+                print(out)
             }
-            out += "-> Could not load Package file: \(error)"
-            print(out)
+            case .Manifest:
+            break
         }
+        
     }
     return true
 }

--- a/atpm/src/validate.swift
+++ b/atpm/src/validate.swift
@@ -21,10 +21,10 @@ func ==(lhs:ExternalDependency.VersioningMethod, rhs: ExternalDependency.Version
 func validateVersions(packages: [ExternalDependency]) -> [String:[ExternalDependency.VersioningMethod]]? {
 	var grouped = [URL:[ExternalDependency]]()
 	for p in packages {
-		if grouped[p.gitURL] == nil {
-			grouped[p.gitURL] = [ExternalDependency]()
+		if grouped[p.url] == nil {
+			grouped[p.url] = [ExternalDependency]()
 		}
-		grouped[p.gitURL]!.append(p)
+		grouped[p.url]!.append(p)
 	}
 
 	var failed = Dictionary<String, Array<ExternalDependency.VersioningMethod>>()
@@ -56,21 +56,21 @@ func validateVersions(packages: [ExternalDependency]) -> [String:[ExternalDepend
 							try versionRange.combine(v)
 						} catch {
 							// so we cannot combine the ranges -> failed
-							if failed[pkg.name] == nil {
-								failed[pkg.name] = []
-								failed[pkg.name]!.append(vMethod)
+							if failed[pkg.name!] == nil {
+								failed[pkg.name!] = []
+								failed[pkg.name!]!.append(vMethod)
 							}
-							failed[pkg.name]!.append(pkg.version)
+							failed[pkg.name!]!.append(pkg.version)
 						}
 					}
 				}
 			} else {
 				// different versioning schemes don't match by definition
-				if failed[pkg.name] == nil {
-					failed[pkg.name] = []
-					failed[pkg.name]!.append(vMethod)
+				if failed[pkg.name!] == nil {
+					failed[pkg.name!] = []
+					failed[pkg.name!]!.append(vMethod)
 				}
-				failed[pkg.name]!.append(pkg.version)
+				failed[pkg.name!]!.append(pkg.version)
 			}
     	}
 	}

--- a/build.atpkg
+++ b/build.atpkg
@@ -105,9 +105,15 @@
       :dependencies ["package-linux" "package-osx"]
     }
 
+    :toolcheck {
+      :tool "shell"
+      :dependencies ["atpm"]
+      :script "bash tests/atpm/test.sh"
+    }
+
     :check {
       :tool "nop"
-      :dependencies ["run-tests"]
+      :dependencies ["run-tests" "toolcheck"]
     }
 
     :build-tests {

--- a/build.atpkg
+++ b/build.atpkg
@@ -88,7 +88,7 @@
       :tool "package-deb.attool"
       :name "atpm"
       :dependencies ["atbin"]
-      :depends "git"
+      :recommends "git coreutils curl ca-certificates"
     }
 
 

--- a/build.atpkg
+++ b/build.atpkg
@@ -88,7 +88,7 @@
       :tool "package-deb.attool"
       :name "atpm"
       :dependencies ["atbin"]
-      :recommends "git coreutils curl ca-certificates"
+      :recommends "git, coreutils, curl, ca-certificates"
     }
 
 

--- a/tests/atpm/binary/build.atlock
+++ b/tests/atpm/binary/build.atlock
@@ -1,6 +1,6 @@
 ;; Anarchy Tools Package Manager lock file
 ;;
-;; If you want to pin a package to a git commit add a ':pin-commit'
+;; If you want to pin a package to a git commit add a ':pin'
 ;; line to that package definition. This will override all version
 ;; information the build files specify.
 ;;
@@ -15,6 +15,8 @@
       :payloads [
     {
       :key "osx"
+      :used-commit "a5280a32b7f7a03e1238f33080ec7c39aacb9ce6"
+      :pin false
       :used-url "https://github.com/AnarchyTools/dummyBinaryPackage/releases/download/0.1/osx.tar.xz"
       :used-version "0.1"
       :sha-sum "c8311dd51dfbdd6f76c312f660f208a163415e5e7fa9f8c87f82ecaf50e0378b"

--- a/tests/atpm/binary/build.atlock
+++ b/tests/atpm/binary/build.atlock
@@ -1,0 +1,25 @@
+;; Anarchy Tools Package Manager lock file
+;;
+;; If you want to pin a package to a git commit add a ':pin-commit'
+;; line to that package definition. This will override all version
+;; information the build files specify.
+;;
+;; You may override the repository URL for a package by specifying
+;; it in an ':override-url' line. This is very handy if you develop
+;; the dependency in parallel to the package that uses it
+
+(lock-file
+  :packages [
+    {
+      :url "https://raw.githubusercontent.com/AnarchyTools/dummyBinaryPackage/master/manifest.atpkg"
+      :payloads [
+    {
+      :key "osx"
+      :used-url "https://github.com/AnarchyTools/dummyBinaryPackage/releases/download/0.1/osx.tar.xz"
+      :used-version "0.1"
+      :sha-sum "c8311dd51dfbdd6f76c312f660f208a163415e5e7fa9f8c87f82ecaf50e0378b"
+    }
+      ]
+    }
+  ]
+)

--- a/tests/atpm/binary/build.atpkg
+++ b/tests/atpm/binary/build.atpkg
@@ -1,0 +1,25 @@
+;; Copyright (c) 2016 Anarchy Tools Contributors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;   http:;;www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(package
+  :name "binary"
+
+  :external-packages [
+    {
+      :url "https://raw.githubusercontent.com/AnarchyTools/dummyBinaryPackage/master/manifest.atpkg"
+      :version [">=1.0"]
+      :channels ["osx"]
+    }
+  ]
+)

--- a/tests/atpm/binary/build.atpkg
+++ b/tests/atpm/binary/build.atpkg
@@ -18,7 +18,7 @@
   :external-packages [
     {
       :url "https://raw.githubusercontent.com/AnarchyTools/dummyBinaryPackage/master/manifest.atpkg"
-      :version ["==0.1"]
+      :version [">=0.1"]
       :channels ["osx"]
     }
   ]

--- a/tests/atpm/binary/build.atpkg
+++ b/tests/atpm/binary/build.atpkg
@@ -18,7 +18,7 @@
   :external-packages [
     {
       :url "https://raw.githubusercontent.com/AnarchyTools/dummyBinaryPackage/master/manifest.atpkg"
-      :version [">=1.0"]
+      :version ["==0.1"]
       :channels ["osx"]
     }
   ]

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -11,7 +11,12 @@ pwd
 # Binary dependencies test
 #
 echo "*** Binary dependencies ***"
+
 pushd "$DIR/binary"
+
+# remove existing tarball, etc
+rm -rf external
+
 $ATPM fetch
 
 echo "validating keys"

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -8,6 +8,17 @@ ATPM="$(pwd)/.atllbuild/products/atpm"
 pwd
 
 #
+# Binary dependencies test
+#
+echo "*** Binary dependencies ***"
+pushd "$DIR/binary"
+$ATPM fetch
+popd
+
+echo "pwd"
+pwd
+
+#
 # Simple dependency fetcher
 #
 

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -15,8 +15,8 @@ pushd "$DIR/binary"
 $ATPM fetch
 
 echo "validating keys"
-if ! grep "1.0" build.atlock; then
-    echo "Failed to find locked version 1.0"
+if ! grep "0.1" build.atlock; then
+    echo "Failed to find locked version 0.1"
     exit 1
 fi
 

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -65,6 +65,10 @@ if ! grep "0.2" build.atlock; then
     exit 1
 fi
 
+## try remaining verbs
+
+$ATPM info
+
 popd
 
 #

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -35,6 +35,28 @@ if ! grep "c8311dd51dfbdd6f76c312f660f208a163415e5e7fa9f8c87f82ecaf50e0378b" bui
     exit 1
 fi
 
+$ATPM pin DummyBinary.osx
+
+if ! grep ':pin true' build.atlock; then
+    echo "Failed to pin"
+    exit 1
+fi
+
+$ATPM update
+
+if ! grep "0.1" build.atlock; then
+    echo "Failed to find locked version 0.1"
+    exit 1
+fi
+
+$ATPM unpin DummyBinary.osx
+
+if ! grep ':pin false' build.atlock; then
+    echo "Failed to pin"
+    exit 1
+fi
+
+
 popd
 
 #

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -13,10 +13,24 @@ pwd
 echo "*** Binary dependencies ***"
 pushd "$DIR/binary"
 $ATPM fetch
-popd
 
-echo "pwd"
-pwd
+echo "validating keys"
+if ! grep "1.0" build.atlock; then
+    echo "Failed to find locked version 1.0"
+    exit 1
+fi
+
+if ! grep "https://github.com/AnarchyTools/dummyBinaryPackage/releases/download/0.1/osx.tar.xz" build.atlock; then
+    echo "Failed to find expected URL"
+    exit 1
+fi
+
+if ! grep "c8311dd51dfbdd6f76c312f660f208a163415e5e7fa9f8c87f82ecaf50e0378b" build.atlock; then
+    echo "Failed to find expected shasum"
+    exit 1
+fi
+
+popd
 
 #
 # Simple dependency fetcher

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -16,6 +16,8 @@ pushd "$DIR/binary"
 
 # remove existing tarball, etc
 rm -rf external
+# checkout locked atlock
+git checkout build.atlock
 
 $ATPM fetch
 
@@ -56,6 +58,12 @@ if ! grep ':pin false' build.atlock; then
     exit 1
 fi
 
+$ATPM update
+
+if ! grep "0.2" build.atlock; then
+    echo "Failed to find the locked version 0.2"
+    exit 1
+fi
 
 popd
 


### PR DESCRIPTION
This PR implements binary releases for atpm.

This is a large PR (sorry!) but it is the smallest PR that I think adequately implements the feature.

PRs which should go in simultaneously:
- this one
- User documentation PR: https://github.com/AnarchyTools/anarchytools.github.io/pull/18
- atpkg PR: https://github.com/AnarchyTools/atpkg/pull/30

See #1
# Design issues
## Channels

One issue with binary releases is there are multiple kinds of binaries per package.  You might have `stable` and `beta`, `linux` and `osx`, `swift-3` and `swift-2`, `dynamic` and `static`, `debug` and `release`, etc.

To resolve this problem (or really, to punt on it), we introduce the notion of a `channel`, which is a kind of subpackage.  A package can have multiple `channels` to provide as many flavors of the software as you wish to publish.  Each channel is versioned independently

This design is not without its problems; notably, breaking the "one thing per package rule" violates several design assumptions of atpm.  This includes: the lock file format (assumes one commit per package), the directory structure (assumes one folder per package), verion logic (one version per package), etc.  These issues are all resolved in this PR.

The alternative solution is to vend e.g. `Foo-linux`, `Foo-osx` etc. everwhere as bona fide separate packages, which would be simpler to implement from atpm point of view.  However, I rejected that approach for several reasons:
- This is not a corner case, e.g. the software I am trying to package immediately has 5+ channels, and multipackages are unwieldy.  There's no way to punt on this until "later"
- Listing the packages in separate manifests would require multiple curl invocations and be less efficient to download, which sounds silly but is an important concern for CI efficiency
- `Foo-osx` isn't _really_ a separate package, and pretending it is (e.g. in the documentation) would be poor nomenclature and confusing to other developers and my downstreams
- A channel-based approach would allow (in the future) the automatic downloading of only binaries for your platform, as opposed to all binaries on all platforms.
## Manifests

Binary packages are implemented via a manifest format.  Importantly, manifests are served over HTTPS (not Git) (although you can use GitHub as a host, just generating an HTTPS URL for the manifest.  This is how our test coverage works).

This is essentially because the software I intend to package does not necessarily have a git repostory to which you would have access, and the cost to spin one up is annoying.

For more on manifests, see the user documentation.
# Implementation issues
## atpkg

Atpkg has been extended to support the parsing of binaries, channels, and manifests.
### Numbered map keys

One notable change is that our parser now supports numbers as map keys.  This is because our manifest wants to list versions that way, e.g.

``` clojure
(package
:name "DummyBinary"

:binaries {
    :channels {
        :linux {
            :0.1 {
                :url "https://github.com/AnarchyTools/dummyBinaryPackage/releases/download/0.1/linux.tar.xz"
            }
        }
        :osx {
            :0.1 {
                :url "https://github.com/AnarchyTools/dummyBinaryPackage/releases/download/0.1/osx.tar.xz"
            }
        }
    }
}
)
```
### ExternalDependency.name

Manifests introduce a new wrinkle: what's the name of a package in a manifest we don't have yet?

It doesn't have a name, unless we go out to the manifest and check.  To better model this, name is now optional, and an internal API, `_parsedNameFromManifest` is used to write the name into the model from atpm.
### ExternalDependency.type

A new API is introduced to detect whether a dependency is Git-based or Manifest-based.  This is used extensively inside atpm to toggle git or manifest-specific behavior.

The current implementation checks the end of the URL for `.atpkg`.  While there are other possibilities (e.g. I prototyped trying to use git on repository and treat as atpkg if it fails), speed is an issue, and this is a fast implementation with no external dependencies.
## atpm
### build dependencies

atpm grows some new dependencies on Linux, in particular `curl` `ca-certificates` and `coreutils`.
### Refactors

Several functions were extracted into "generic" parts and "git/manifest specific" parts.  For example, the `fetchDependency` function now chains to `fetchHTTP` `fetchGit`, etc.  Some other "common" logic has been extracted into helper functions like version resolution, so it can be used from both places.
### Plaintext

Due to https://github.com/AnarchyTools/atbuild/issues/106, it's a considerable risk to have unsecured packages.  Therefore, we force HTTPS for manifests and binary downloads.

We should probably do that for git as well, although it's not included in this PR.
### Test coverage

Reasonably thorough test coverage is introduced for binary packages.  It would be nice to have this for git packages as well, but it's outside the scope of this PR.  Note that what test coverage there is, now runs via `atbuild check` and also CI.
### atlock changes

The lock format was significantly reworked to support multiple payloads per package to solve the channels problem.  In particular, old lock files are not compatible, and should be deleted and recreated.  I don't believe we have enough usage to make that kind of breakage a problem, (not even atbuild uses atpm yet) but obviously raise a flag if it is.

Structs were also chosen in a few places due to the complexity of merging atlock data as we now have many more values related to binaries.  After discussion, there was no particular design reason for using classes to begin with, so this shouldn't be an issue.

`pinnedCommitID` the string is now just `pin` the bool, indicating whether the package is pinned or not.  This is because the implementation of pinning varies (commitsha in the git case, or version in the manifest case).  We already have perfectly good fields for versions and commits, so `pin` just controls whether those fields will be updated.
### Hax

The HTTP `fetch` function is sufficiently involved that it really needs to export certain kinds of state to the rest of the program:
- The lock data (e.g. shasums and such) which is quite involved and cannot be easily recreated as a commit sha can
- The package name, which is parsed out of the manifest and is tricky to acquire later

Various hacks were implemented to export this data to other interested parts of atpm.
### Errata

In a few places `fclose` was formerly used which is a bug on OSX, `pclose` is the correct way to close `popen` and caused memory corruption issues.

Added a new "Unspecified error" print for some error conditions that had no explicit message; I hit those during development of this PR.
