### PR TITLE
Use configurations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ linux:
         - apt-get install atbuild package-deb -y
         - git submodule update --recursive --init
         - atbuild check
-        - atbuild package --use-overlay static
+        - atbuild package --use-overlay static --configuration release
     tags:
         - autoscale-linux
     image: drewcrawford/swift:latest
@@ -24,7 +24,7 @@ osx:
     script:
         - git submodule update --recursive --init
         - atbuild check
-        - atbuild package --use-overlay static
+        - atbuild package --use-overlay static --configuration release
     tags:
         - openswift
         - atbuild


### PR DESCRIPTION
This uses the release configuration introduced in atbuild 1.4.0

This enables optimizations in atpm binaries pulled from CI, etc.
