### PR TITLE
Binary package hotfix rollup

### DIFF
--- a/atpm/src/dependency.swift
+++ b/atpm/src/dependency.swift
@@ -64,6 +64,7 @@ func fetchDependency(_ pkg: ExternalDependency, lock: LockedPackage?) throws {
 
     //note that this check only works for git dependencies – 
     //binary dependencies names are defined in the manifest
+    //additionally, this does not segregate by "channels" as would be needed for that case
     if let name = pkg.name {
         if FS.fileExists(path: Path("external/\(name)")) {
             print("Already downloaded")

--- a/atpm/src/main.swift
+++ b/atpm/src/main.swift
@@ -101,7 +101,7 @@ func fetch(_ package: Package, lock: LockFile?) -> [ExternalDependency] {
             }
             
         } catch {
-            print("ERROR: Could not fetch \(pkg.name!): \(error)")
+            print("ERROR: Could not fetch \(pkg.url): \(error)")
             exit(1)
         }
     }
@@ -276,7 +276,6 @@ func writeLockFile(_ packages: [ExternalDependency], lock: LockFile?) {
                 lockedPackage.payloads = []
                 for payload in info.channels {
                     lockedPackage.payloads.append(payload.lockedPayload)
-                    print("appending \(payload)")
                 }
             }
 


### PR DESCRIPTION
This PR resolves several issues uncovered while packaging Caroline.
- Binary channels are now segregated into different folders on disk.  This is important because multiple channels may try to ship the same file (Caroline.framework for example) e.g. for different OSes or whatever.
- Resolving a crash that can occur when an error occurs fetching a manifest
- Removing a debug print
- Supporting unzipping of files; zip is a common format for frameworks
