### PR TITLE
Resolves a bug where `atpm update` fails to update a package

### DIFF
--- a/atpm/src/git.swift
+++ b/atpm/src/git.swift
@@ -52,7 +52,7 @@ func updateGitDependency(_ pkg: ExternalDependency, lock: LockedPackage?, firstT
     }
 
     // If we are pinned only checkout that commit
-    if let lock = lock where lock.gitPayload.pinned != nil {
+    if let lock = lock where lock.gitPayload.pinned == true {
         print("Package \(pkg.name!) is pinned to \(lock.gitPayload.usedCommitID!)")
         let pullResult = logAndExecute(command: "cd 'external/\(pkg.name!)' && git checkout '\(lock.gitPayload.usedCommitID!)'")
         if pullResult != 0 {

--- a/tests/atpm/not-pinned/build.atpkg
+++ b/tests/atpm/not-pinned/build.atpkg
@@ -1,0 +1,24 @@
+;; Copyright (c) 2016 Anarchy Tools Contributors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;   http:;;www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(package
+  :name "not_pinned"
+
+  :external-packages [
+    {
+      :url "https://github.com/AnarchyTools/dummyPackageB.git"
+      :branch "master"
+    }
+  ]
+)

--- a/tests/atpm/not-pinned/build.useme.atlock
+++ b/tests/atpm/not-pinned/build.useme.atlock
@@ -1,0 +1,24 @@
+;; Anarchy Tools Package Manager lock file
+;;
+;; If you want to pin a package to a git commit add a ':pin'
+;; line to that package definition. This will override all version
+;; information the build files specify.
+;;
+;; You may override the repository URL for a package by specifying
+;; it in an ':override-url' line. This is very handy if you develop
+;; the dependency in parallel to the package that uses it
+
+(lock-file
+  :packages [
+    {
+      :url "https://github.com/AnarchyTools/dummyPackageB.git"
+      :payloads [
+    {
+      :key "git"
+      :used-commit "303b970952450f040be21f8aee26d79dd23e37db" ;; don't update!
+      :pin false
+    }
+      ]
+    }
+  ]
+)

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -72,6 +72,26 @@ $ATPM info
 popd
 
 #
+# not-pinned test
+#
+
+pushd "$DIR/not-pinned"
+$ATPM fetch
+cp build.useme.atlock build.atlock
+$ATPM update
+
+cd "external/dummyPackageB"
+
+COMMIT=`git rev-parse HEAD`
+
+if [ "$COMMIT" == "303b970952450f040be21f8aee26d79dd23e37db" ]; then
+    echo "Still at initial commit – Didn't update"
+    exit 1
+fi
+
+popd
+
+#
 # Simple dependency fetcher
 #
 


### PR DESCRIPTION
Due to a failed condition check, `atpm update` assumes some packages are pinned when they are not.

Add test coverage for this condition
