### PR TITLE
Ignore mistmatches between version and branch.

### DIFF
--- a/atpm/src/validate.swift
+++ b/atpm/src/validate.swift
@@ -65,6 +65,14 @@ func validateVersions(packages: [ExternalDependency]) -> [String:[ExternalDepend
 					}
 				}
 			} else {
+
+				switch(vMethod, pkg.version) {
+					case (.Branch(let b), .Version(let t)), (.Version(let t), .Branch(let b)):
+					print("Warning: Not resolving \(b), \(t) since they are branch and tag.  You're on your own.")
+					continue
+					default:
+					break
+				}
 				// different versioning schemes don't match by definition
 				if failed[pkg.name!] == nil {
 					failed[pkg.name!] = []

--- a/tests/atpm/branchtag/build.atpkg
+++ b/tests/atpm/branchtag/build.atpkg
@@ -1,0 +1,28 @@
+;; Copyright (c) 2016 Anarchy Tools Contributors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;   http:;;www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(package
+  :name "branchtag"
+
+  :external-packages [
+    {
+      :url "https://github.com/AnarchyTools/dummyPackageA.git"
+      :version [">=0.1"]
+    }
+    {
+      :url "https://github.com/AnarchyTools/dummyPackageA.git"
+      :branch "master"
+    }
+  ]
+)

--- a/tests/atpm/test.sh
+++ b/tests/atpm/test.sh
@@ -8,6 +8,17 @@ ATPM="$(pwd)/.atllbuild/products/atpm"
 pwd
 
 #
+# branch-tag
+#
+echo "*** branch-tag ***"
+
+pushd "$DIR/branchtag"
+rm -rf external
+rm -rf build.atlock
+$ATPM fetch
+popd
+
+#
 # if-including test
 #
 echo "*** If-including (selective) ***"


### PR DESCRIPTION
In common cases, one dependency may be satisfied with a released version (e.g. 1.0, etc.) while another dependency may insist on using a development branch (such as master).  Master is generally going to be later than 1.0, but atpm is more pessimistic.

Change this case to a warning.  Ideally we would verify whether or not master is later than the tag but that is complex, and this solves my problem.
